### PR TITLE
changed iris-community to irishealth-community

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG IMAGE=intersystemsdc/iris-community:2020.2.0.204.0-zpm
 ARG IMAGE=intersystemsdc/irishealth-community:2020.2.0.204.0-zpm
 ARG IMAGE=intersystemsdc/irishealth-community:2020.3.0.200.0-zpm
 #Replaced with below image to fix Error: Invalid Community Edition license
-ARG IMAGE=intersystemsdc/iris-community:2021.1.0.215.3-zpm
+ARG IMAGE=intersystemsdc/irishealth-community:2021.1.0.215.3-zpm
 FROM $IMAGE
 
 USER root


### PR DESCRIPTION
It fails during build phase.
I believe this should be irishealth-community.

DO ##CLASS(HS.HC.Util.Installer).InstallFoundation(namespace)
^
<CLASS DOES NOT EXIST> *HS.HC.Util.Installer
%SYS>
